### PR TITLE
OPS-13422 terraform cli cache code

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
 ## Supported Inputs
 >The workflow supports the following inputs.
 
-`terraform_version` The version of terraform to use while using this wrapper. It expects the terraform binary to be in "/usr/local/bin" and the binary to be named in format terraform**version-major**. If the binary is not installed please use the **ensure** action. *Required: True*
+`terraform_version` The version of terraform to use. If the binary is not installed please use the **ensure** action. *Required: True*
 
 `command` The action to perform. The terraform actions supported are **init**, **plan**, **apply**, **destroy**. There is an additional action defined **ensure** that checks if you have the exact version of terraform provided as terraform version in workflow installed, or it will download and place the binary on **$PATH**. *Required: True*
 

--- a/lib/apply.js
+++ b/lib/apply.js
@@ -1,12 +1,12 @@
 const core = require("@actions/core");
 const path = require("path")
 const exec = require("@actions/exec")
+const tc = require('@actions/tool-cache');
 
 async function apply() {
     try {
         const version = core.getInput("terraform_version");
-        const versionsSet = version.split(".");
-        const majorVer = (versionsSet[0] = "0") ? versionsSet[1] : versionsSet[0];
+        let toolPath = tc.find("terraform", version);
         const aws_access_key_id = core.getInput("aws_access_key_id");
         const aws_secret_access_key = core.getInput("aws_secret_access_key");
         const region = core.getInput("aws_region");
@@ -15,7 +15,7 @@ async function apply() {
         core.info(`Changing directories to working directory`);
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")));
         core.info(`Starting terraform apply`);
-        const execfile = `terraform${majorVer}`
+        const execfile = `${toolPath}/terraform`
         const workspaceargs = makeWorkspaceOrNot(core.getInput("create-workspace"), core.getInput("workspace"));
         const planargs = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         core.startGroup(`Terraform Apply`);

--- a/lib/destroy.js
+++ b/lib/destroy.js
@@ -1,12 +1,12 @@
 const core = require("@actions/core");
 const path = require("path");
 const exec = require("@actions/exec")
+const tc = require('@actions/tool-cache');
 
 async function destroy() {
     try {
         const version = core.getInput("terraform_version");
-        const versionsSet = version.split(".");
-        const majorVer = (versionsSet[0] = "0") ? versionsSet[1] : versionsSet[0];
+        let toolPath = tc.find("terraform", version);
         const aws_access_key_id = core.getInput("aws_access_key_id");
         const aws_secret_access_key = core.getInput("aws_secret_access_key")
         const region = core.getInput("aws_region");
@@ -15,7 +15,7 @@ async function destroy() {
         core.info(`Changing directories to working directory`)
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")));
         core.info(`Starting terraform destroy`);
-        const execfile = `terraform${majorVer}`;
+        const execfile = `${toolPath}/terraform`
         const workspaceargs = makeWorkspaceOrNot(core.getInput("create-workspace"), core.getInput("workspace"));
         const planargs = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         core.startGroup(`Terraform Destroy`);

--- a/lib/ensure.js
+++ b/lib/ensure.js
@@ -2,33 +2,27 @@ const core = require("@actions/core");
 const tc = require('@actions/tool-cache');
 const fs = require('fs');
 const util = require('util');
-const exec = util.promisify(require('child_process').exec);
 
 async function ensure() {
-    try{
+    try {
         const version = core.getInput("terraform_version");
-        const versionsSet = version.split(".");
-        const majorVer = (versionsSet[0] = "0") ? versionsSet[1] : versionsSet[0];
-        const installpath = `/usr/local/bin/terraform${majorVer}`;
-        if (fs.existsSync(installpath)) {
-            core.info(`File exists at ${installpath}`);
-        } else {
-            core.info(`File does not exist at ${installpath}`);
+        let toolPath = tc.find("terraform", version);
+
+        if (!toolPath) {
             const downloadurl = `https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip`;
             core.info(`Downloading Terraform CLI from ${downloadurl}`);
             const pathToCLIZip = await tc.downloadTool(downloadurl);
-            core.info('Extracting Terraform CLI zip file');
-            const pathToCLI = await tc.extractZip(pathToCLIZip, "/tmp");
-            core.info(`Terraform CLI path is ${pathToCLI}.`);
+            const pathToCLI = await tc.extractZip(pathToCLIZip);
+
             if (!pathToCLIZip || !pathToCLI) {
                 throw new Error(`Unable to download Terraform from ${downloadurl}`);
             }
-            core.info(`Copying and changing file permissions at ${installpath}`);
-            const { stdout, stderr } = await exec(`mv /tmp/terraform ${installpath} && chmod 777 ${installpath}`);
-            core.info(`stdout: ${stdout}`);
-            core.info(`stderr:, ${stderr}`);
-            core.info(`File permissions changed!`);
+            toolPath = await tc.cacheDir(pathToCLI, "terraform", version);
         }
+        else {
+            core.info(`tf-${version} cache found at location ${toolPath}`)
+        }
+        core.addPath(toolPath);
     } catch (err) {
         core.error(err);
         throw err;

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,11 +1,12 @@
 const core = require("@actions/core");
 const path = require("path");
 const exec = require("@actions/exec")
+const tc = require('@actions/tool-cache');
 
 async function init() {
     try {
         const version = core.getInput("terraform_version");
-        const versionsSet = version.split(".");
+        let toolPath = tc.find("terraform", version);
         const aws_access_key_id = core.getInput("aws_access_key_id");
         const aws_secret_access_key = core.getInput("aws_secret_access_key")
         const region = core.getInput("aws_region");
@@ -13,10 +14,9 @@ async function init() {
         const prefix = core.getInput("stateprefix")
         process.env['AWS_DEFAULT_REGION'] = `${region}`;
         addEnvVars(aws_access_key_id, aws_secret_access_key);
-        const majorVer = (versionsSet[0] = "0") ? versionsSet[1] : versionsSet[0];
         core.info(`Changing directories to working directory`)
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")))
-        const execfile = `terraform${majorVer}`
+        const execfile = `${toolPath}/terraform`
         const args = makeInitArgs(bucket, prefix, region)
         core.startGroup(`Init info`);
         core.info(`Starting terraform init with command ${execfile} ${args}`);

--- a/lib/plan.js
+++ b/lib/plan.js
@@ -2,12 +2,12 @@ const core = require("@actions/core");
 const util = require('util');
 const path = require("path")
 const exec = util.promisify(require('child_process').exec);
+const tc = require('@actions/tool-cache');
 
 async function plan() {
     try {
         const version = core.getInput("terraform_version");
-        const versionsSet = version.split(".");
-        const majorVer = (versionsSet[0] = "0") ? versionsSet[1] : versionsSet[0];
+        let toolPath = tc.find("terraform", version);
         const aws_access_key_id = core.getInput("aws_access_key_id");
         const aws_secret_access_key = core.getInput("aws_secret_access_key")
         const region = core.getInput("aws_region");
@@ -15,7 +15,7 @@ async function plan() {
         addEnvVars(aws_access_key_id, aws_secret_access_key)
         const plancmd = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         const workspaceargs = makeWorkspaceOrNot(core.getInput("create-workspace"), core.getInput("workspace"))
-        const execfile = `terraform${majorVer}`
+        const execfile = `${toolPath}/terraform`
         core.info(`Changing directories to working directory`)
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")))
         core.startGroup(`Terraform Apply`);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,18 +1,18 @@
 const core = require("@actions/core");
 const path = require("path")
 const exec = require("@actions/exec")
+const tc   = require('@actions/tool-cache');
 
 async function validate() {
     try {
         const version = core.getInput("terraform_version");
-        const versionsSet = version.split(".");
-        const majorVer = (versionsSet[0] = "0") ? versionsSet[1] : versionsSet[0];
+        let toolPath = tc.find("terraform", version);
         const region = core.getInput("aws_region");
         process.env['AWS_DEFAULT_REGION'] = `${region}`;
         core.info(`Changing directories to working directory`);
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")));
         core.info(`Starting terraform validate`);
-        const execfile = `terraform${majorVer}`;
+        const execfile = `${toolPath}/terraform`
         core.startGroup(`Terraform Validate`);
         await exec.exec(execfile, [`validate`]);
         core.endGroup();


### PR DESCRIPTION
Tested, so when use ensure, it download the version then that will store and cache inside folder as mentioned below
```
Run ./.github/actions/ghactions-terraform-aws
Running command ensure...
tf-0.13.7 cache found at location /srv/ghrunner/actions-runner/_work/_tool/terraform/0.13.7/x64
```
In the next steps, it will be used like below.
  ```
/srv/ghrunner/actions-runner/_work/_tool/terraform/0.13.7/x64/terraform init -force-copy -backend-config region=eu-west-1 -backend-config bucket=shared-apps-terraform-app-states -backend-config key=apps/gh-poc
```