### PR TITLE
OPS-13419 workspace creation exit code handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ jobs:
 
 `workspace` The workspace to use. Uses **default** workspace by default. *Required: False*
 
+`create-workspace` Set to **true** if a new terraform workspace has to be created, the workspace name would be set by the **workspace** input. *Required: false*
+
 `aws_region` The AWS region to use AWS provisioning for. Default is **eu-west-1**. Use this to switch your region. *Required: False*
 
 `aws_access_key_id` You can opt to use your access key id to provision the workflow or ensure you use a github runner that has appropriate IAM permissions to provision your infra. In the former case this is a mandatory parameter. To use this it is recommended to store this as your repo secret and use this as 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ jobs:
 
 `target` Set targets for plan and apply. Default value is empty. *Required: False*, for an example target: "-target=aws_s3_bucket.random"
 
-`create-workspace` Set to **true** if a new terraform workspace has to be created, the workspace name would be set by the **workspace** input. *Required: false*
-
 `workspace` The workspace to use. Uses **default** workspace by default. *Required: False*
 
 `aws_region` The AWS region to use AWS provisioning for. Default is **eu-west-1**. Use this to switch your region. *Required: False*

--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,6 @@ inputs:
     description: 'The workspace to use to apply changes'
     default: 'default'
     required: false
-  create-workspace:
-    description: 'Set to True if workspace need to be created'
-    default: 'false'
-    required: false
   aws_region:
     description: 'The AWS region'
     default: 'eu-west-1'

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: 'The workspace to use to apply changes'
     default: 'default'
     required: false
+  create-workspace:
+    description: 'Set to True if workspace need to be created'
+    default: 'false'
+    required: false    
   aws_region:
     description: 'The AWS region'
     default: 'eu-west-1'

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
   create-workspace:
     description: 'Set to True if workspace need to be created'
     default: 'false'
-    required: false    
+    required: false
   aws_region:
     description: 'The AWS region'
     default: 'eu-west-1'

--- a/lib/apply.js
+++ b/lib/apply.js
@@ -16,11 +16,11 @@ async function apply() {
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")));
         core.info(`Starting terraform apply`);
         const execfile = `${toolPath}/terraform`
-        const workspaceargs = makeWorkspaceOrNot(core.getInput("create-workspace"), core.getInput("workspace"));
+        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
         const planargs = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         core.startGroup(`Terraform Apply`);
-        core.info(`Starting terraform workspace switch with command ${execfile}`);
-        await exec.exec(execfile, workspaceargs);
+        core.info(`Starting terraform workspace switch with command ${workspaceargs}`);
+        await exec.exec('/bin/bash', ['-c', workspaceargs]);
         await exec.exec(execfile, planargs);
         await exec.exec(execfile, [`apply`, `${core.getInput("planfile")}`])
         core.endGroup();
@@ -30,11 +30,8 @@ async function apply() {
     }
 }
 
-function makeWorkspaceOrNot(createworkspace, workspace) {
-    if (createworkspace != "false") {
-        return [`workspace`, `new`, `${workspace}`]
-    }
-    return [`workspace`, `select`, `${workspace}`]
+function makeWorkspaceIfNotExits(execfile, workspace) {
+    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
 }
 
 function addEnvVars(aws_access_key_id, aws_secret_access_key) {

--- a/lib/apply.js
+++ b/lib/apply.js
@@ -2,6 +2,7 @@ const core = require("@actions/core");
 const path = require("path")
 const exec = require("@actions/exec")
 const tc = require('@actions/tool-cache');
+const make_ws = require("./makews");
 
 async function apply() {
     try {
@@ -16,11 +17,9 @@ async function apply() {
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")));
         core.info(`Starting terraform apply`);
         const execfile = `${toolPath}/terraform`
-        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
+        await make_ws(core.getInput("create-workspace"), core.getInput("workspace"), execfile)
         const planargs = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         core.startGroup(`Terraform Apply`);
-        core.info(`Starting terraform workspace switch with command ${workspaceargs}`);
-        await exec.exec('/bin/bash', ['-c', workspaceargs]);
         await exec.exec(execfile, planargs);
         await exec.exec(execfile, [`apply`, `${core.getInput("planfile")}`])
         core.endGroup();
@@ -28,10 +27,6 @@ async function apply() {
         core.error(err);
         throw err;
     }
-}
-
-function makeWorkspaceIfNotExits(execfile, workspace) {
-    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
 }
 
 function addEnvVars(aws_access_key_id, aws_secret_access_key) {

--- a/lib/destroy.js
+++ b/lib/destroy.js
@@ -2,6 +2,7 @@ const core = require("@actions/core");
 const path = require("path");
 const exec = require("@actions/exec")
 const tc = require('@actions/tool-cache');
+const make_ws = require("./makews");
 
 async function destroy() {
     try {
@@ -16,11 +17,9 @@ async function destroy() {
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")));
         core.info(`Starting terraform destroy`);
         const execfile = `${toolPath}/terraform`
-        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
+        await make_ws(core.getInput("create-workspace"), core.getInput("workspace"), execfile)
         const planargs = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         core.startGroup(`Terraform Destroy`);
-        core.info(`Starting terraform workspace switch with command ${workspaceargs}`);
-        await exec.exec('/bin/bash', ['-c', workspaceargs]);
         await exec.exec(execfile, planargs);
         await exec.exec(execfile, [`apply`, `${core.getInput("planfile")}`])
         core.endGroup();
@@ -30,9 +29,6 @@ async function destroy() {
     }
 }
 
-function makeWorkspaceIfNotExits(execfile, workspace) {
-    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
-}
 function addEnvVars(aws_access_key_id, aws_secret_access_key) {
     if (aws_access_key_id != "acracadabra_id") {
         core.info(`**** IMPORTANT: Setting provided AWS Credentials ****`);

--- a/lib/destroy.js
+++ b/lib/destroy.js
@@ -16,11 +16,11 @@ async function destroy() {
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")));
         core.info(`Starting terraform destroy`);
         const execfile = `${toolPath}/terraform`
-        const workspaceargs = makeWorkspaceOrNot(core.getInput("create-workspace"), core.getInput("workspace"));
+        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
         const planargs = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         core.startGroup(`Terraform Destroy`);
-        core.info(`Starting terraform workspace switch with command ${execfile}`);
-        await exec.exec(execfile, workspaceargs);
+        core.info(`Starting terraform workspace switch with command ${workspaceargs}`);
+        await exec.exec('/bin/bash', ['-c', workspaceargs]);
         await exec.exec(execfile, planargs);
         await exec.exec(execfile, [`apply`, `${core.getInput("planfile")}`])
         core.endGroup();
@@ -30,13 +30,9 @@ async function destroy() {
     }
 }
 
-function makeWorkspaceOrNot(createworkspace, workspace) {
-    if (createworkspace != "false") {
-        return [`workspace`, `new`, `${workspace}`]
-    }
-    return [`workspace`, `select`, `${workspace}`]
+function makeWorkspaceIfNotExits(execfile, workspace) {
+    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
 }
-
 function addEnvVars(aws_access_key_id, aws_secret_access_key) {
     if (aws_access_key_id != "acracadabra_id") {
         core.info(`**** IMPORTANT: Setting provided AWS Credentials ****`);

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,6 +2,7 @@ const core = require("@actions/core");
 const path = require("path");
 const exec = require("@actions/exec")
 const tc = require('@actions/tool-cache');
+const make_ws = require("./makews");
 
 async function init() {
     try {
@@ -21,8 +22,7 @@ async function init() {
         core.startGroup(`Init info`);
         core.info(`Starting terraform init with command ${execfile} ${args}`);
         await exec.exec(execfile, args);
-        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
-        await exec.exec('/bin/bash', ['-c', workspaceargs]);
+        await make_ws(core.getInput("create-workspace"), core.getInput("workspace"), execfile)
         await exec.exec(execfile, args);
         core.endGroup();
     } catch (err) {
@@ -46,10 +46,5 @@ function makeInitArgs(bucket, prefix, region) {
     }
     return [`init`]
 }
-
-function makeWorkspaceIfNotExits(execfile, workspace) {
-    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
-}
-
 
 module.exports = init;

--- a/lib/init.js
+++ b/lib/init.js
@@ -21,8 +21,8 @@ async function init() {
         core.startGroup(`Init info`);
         core.info(`Starting terraform init with command ${execfile} ${args}`);
         await exec.exec(execfile, args);
-        const workspaceargs = makeWorkspaceOrNot(core.getInput("create-workspace"), core.getInput("workspace"))
-        await exec.exec(execfile, workspaceargs);
+        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
+        await exec.exec('/bin/bash', ['-c', workspaceargs]);
         await exec.exec(execfile, args);
         core.endGroup();
     } catch (err) {
@@ -42,16 +42,14 @@ function addEnvVars(aws_access_key_id, aws_secret_access_key) {
 
 function makeInitArgs(bucket, prefix, region) {
     if (bucket != '' && prefix != '') {
-        return [ `init`, `-force-copy`, `-backend-config`, `region=${region}`, `-backend-config`, `bucket=${bucket}`, `-backend-config`, `key=${prefix}`]
+        return [`init`, `-force-copy`, `-backend-config`, `region=${region}`, `-backend-config`, `bucket=${bucket}`, `-backend-config`, `key=${prefix}`]
     }
     return [`init`]
 }
 
-function makeWorkspaceOrNot(createworkspace, workspace) {
-    if (createworkspace != "false") {
-        return [`workspace`, `new`, `${workspace}`]
-    }
-    return [`workspace`, `select`, `${workspace}`]
+function makeWorkspaceIfNotExits(execfile, workspace) {
+    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
 }
+
 
 module.exports = init;

--- a/lib/makews.js
+++ b/lib/makews.js
@@ -1,0 +1,49 @@
+const core = require("@actions/core");
+const exec = require("@actions/exec")
+
+async function makews(createworkspace, workspace, execfile) {
+    try {
+        let stdout = '';
+        let stderr = '';
+
+        const options = {};
+        options.listeners = {
+            stdout: (data) => {
+                stdout = data.toString();
+            },
+            stderr: (data) => {
+                stderr = data.toString();
+            }
+        };
+        options.cwd = './';
+        await exec.exec(execfile, [`workspace`, `list`], options);
+
+        if (createworkspace != "false") {
+            if (matchExact(new RegExp(`^${workspace}$`, 'gm'), stdout)) {
+                core.info(`workspace does not exists, creating as create-workspace param not set to false`)
+                await exec.exec(execfile, [`workspace`, `new`, `${workspace}`]);
+                return true
+            }
+        }
+
+        if (matchExact(new RegExp(`\\* ${workspace}$`, 'gm'), stdout)) {
+            core.info(`workspace already switched to ${workspace}`)
+            return true
+        }
+
+        core.info(`workspace already exists, switching to workspace ${workspace}`)
+        await exec.exec(execfile, [`workspace`, `select`, `${workspace}`]);
+        return true
+        
+    } catch (err) {
+        core.error(err);
+        throw err;
+    }
+}
+
+function matchExact(r, str) {
+    var match = r.test(str)
+    return match
+}
+
+module.exports = makews;

--- a/lib/plan.js
+++ b/lib/plan.js
@@ -14,13 +14,13 @@ async function plan() {
         process.env['AWS_DEFAULT_REGION'] = `${region}`;
         addEnvVars(aws_access_key_id, aws_secret_access_key)
         const plancmd = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
-        const workspaceargs = makeWorkspaceOrNot(core.getInput("create-workspace"), core.getInput("workspace"))
         const execfile = `${toolPath}/terraform`
+        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
         core.info(`Changing directories to working directory`)
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")))
         core.startGroup(`Terraform Apply`);
-        core.info(`Starting terraform workspace switch with command ${execfile}`);
-        await exec.exec(execfile, workspaceargs);
+        core.info(`Starting terraform workspace switch with command ${workspaceargs}`);
+        await exec.exec('/bin/bash', ['-c', workspaceargs]);
         core.info(`Starting terraform plan with command ${plancmd}`);
         await exec.exec(execfile, plancmd);
         core.endGroup();
@@ -30,11 +30,8 @@ async function plan() {
     }
 }
 
-function makeWorkspaceOrNot(createworkspace, workspace) {
-    if (createworkspace != "false") {
-        return [`workspace`, `new`, `${workspace}`]
-    }
-    return [`workspace`, `select`, `${workspace}`]
+function makeWorkspaceIfNotExits(execfile, workspace) {
+    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
 }
 
 function addEnvVars(aws_access_key_id, aws_secret_access_key) {

--- a/lib/plan.js
+++ b/lib/plan.js
@@ -3,6 +3,7 @@ const util = require('util');
 const path = require("path")
 const exec = util.promisify(require('child_process').exec);
 const tc = require('@actions/tool-cache');
+const make_ws = require("./makews");
 
 async function plan() {
     try {
@@ -15,12 +16,10 @@ async function plan() {
         addEnvVars(aws_access_key_id, aws_secret_access_key)
         const plancmd = makePlanCmd(core.getInput("varsfile"), core.getInput("planfile"), core.getInput("target"));
         const execfile = `${toolPath}/terraform`
-        const workspaceargs = makeWorkspaceIfNotExits(execfile, core.getInput("workspace"))
         core.info(`Changing directories to working directory`)
         process.chdir(path.join(process.cwd(), core.getInput("working-directory")))
+        await make_ws(core.getInput("create-workspace"), core.getInput("workspace"), execfile)
         core.startGroup(`Terraform Apply`);
-        core.info(`Starting terraform workspace switch with command ${workspaceargs}`);
-        await exec.exec('/bin/bash', ['-c', workspaceargs]);
         core.info(`Starting terraform plan with command ${plancmd}`);
         await exec.exec(execfile, plancmd);
         core.endGroup();
@@ -28,10 +27,6 @@ async function plan() {
         core.error(err);
         throw err;
     }
-}
-
-function makeWorkspaceIfNotExits(execfile, workspace) {
-    return [`${execfile} workspace select ${workspace} || ${execfile} workspace new ${workspace}`]
 }
 
 function addEnvVars(aws_access_key_id, aws_secret_access_key) {


### PR DESCRIPTION
So, with the old implementation, you have to specify the `create-workspace` param to create otherwise it will not create and the pipeline will fail by saying workspace doesn’t exist.

and if you specify the param `create-workspace`: `true`, it will create the first time but 2nd-time pipeline will fail again by saying workspace already exits. and we have to set `create-workspace`: `false` again to make the pipeline work.